### PR TITLE
Alternate partitioning shemes

### DIFF
--- a/DVIDSparkServices/reconutils/Evaluate.py
+++ b/DVIDSparkServices/reconutils/Evaluate.py
@@ -261,18 +261,18 @@ class Evaluate(object):
             parent_list = set()
 
             subvolume_pts = {}
-            roi = stats.subvolume.roi
+            box = stats.subvolume.box
             # grab points that overlap
             for index, point in enumerate(point_data["point-list"]):
-                if point[0] < roi.x2 and point[0] >= roi.x1 and point[1] < roi.y2 and point[1] >= roi.y1 and point[2] < roi.z2 and point[2] >= roi.z1:
-                    subvolume_pts[index] = [point[0]-roi.x1, point[1]-roi.y1, point[2]-roi.z1]
+                if point[0] < box.x2 and point[0] >= box.x1 and point[1] < box.y2 and point[1] >= box.y1 and point[2] < box.z2 and point[2] >= box.z1:
+                    subvolume_pts[index] = [point[0]-box.x1, point[1]-box.y1, point[2]-box.z1]
                     adjacency_list[index] = set()
                     for iter1 in range(3, len(point)):
                         adjacency_list[index].add(point[iter1])
 
             # find points that have a parent (connection) outside of subvolume
             for index, point in enumerate(point_data["point-list"]):
-                if point[0] >= roi.x2 or point[0] < roi.x1 or point[1] >= roi.y2 or point[1] < roi.y1 or point[2] >= roi.z2 or point[2] < roi.z1:
+                if point[0] >= box.x2 or point[0] < box.x1 or point[1] >= box.y2 or point[1] < box.y1 or point[2] >= box.z2 or point[2] < box.z1:
                     for iter1 in range(3, len(point)):
                         if point[iter1] in adjacency_list:
                             parent_list.add(point[iter1])
@@ -446,7 +446,7 @@ class Evaluate(object):
         for subvol_stats in all_stats:
             subvolume_metrics = {}
             # load substack location/size info 
-            subvolume_metrics["roi"] = subvol_stats.subvolume.roi
+            subvolume_metrics["roi"] = subvol_stats.subvolume.box
             subvolume_metrics["types"] = {}
 
             # subvolume stats per comparison type (defines good)

--- a/DVIDSparkServices/reconutils/Evaluate.py
+++ b/DVIDSparkServices/reconutils/Evaluate.py
@@ -465,9 +465,9 @@ class Evaluate(object):
             
             for stat in subvol_stats.subvolume_stats:
                 # write local stats and accumulate
-                stat.write_to_dict(subvolume_metrics["types"], allsubvolume_metrics, subvol_stats.subvolume.roi_id)
+                stat.write_to_dict(subvolume_metrics["types"], allsubvolume_metrics, subvol_stats.subvolume.sv_index)
 
-            allsubvolume_metrics["ids"][subvol_stats.subvolume.roi_id] = subvolume_metrics
+            allsubvolume_metrics["ids"][subvol_stats.subvolume.sv_index] = subvolume_metrics
             
             # accumulate stats
             if whole_volume_stats is None:

--- a/DVIDSparkServices/reconutils/Segmentor.py
+++ b/DVIDSparkServices/reconutils/Segmentor.py
@@ -236,7 +236,7 @@ class Segmentor(object):
             @wraps(f)
             def wrapped(item):
                 subvol = item[0]
-                x1, y1, z1, x2, y2, z2 = subvol.roi_with_border
+                z1, y1, x1, z2, y2, x2 = subvol.roi_with_border
                 assert isinstance(subvol, Subvolume), "Key must be a Subvolume object"
         
                 if allow_read:
@@ -440,9 +440,9 @@ class Segmentor(object):
                 # extract labels 64
                 border = subvolume.border
                 # get sizes of roi
-                size1 = subvolume.roi[3]+2*border-subvolume.roi[0]
-                size2 = subvolume.roi[4]+2*border-subvolume.roi[1]
-                size3 = subvolume.roi[5]+2*border-subvolume.roi[2]
+                size_z = subvolume.roi.z2 + 2*border - subvolume.roi.z1
+                size_y = subvolume.roi.y2 + 2*border - subvolume.roi.y1
+                size_x = subvolume.roi.x2 + 2*border - subvolume.roi.x1
                  
                 # retrieve data from roi start position considering border
                 @auto_retry(3, pause_between_tries=60.0, logging_name=__name__)
@@ -453,12 +453,12 @@ class Segmentor(object):
                     # Note: libdvid uses zyx order for python functions
                     if resource_server != "":  
                         return node_service.get_labels3D(str(pdconf["segmentation-name"]),
-                                (size3,size2,size1),
-                                (subvolume.roi[2]-border, subvolume.roi[1]-border, subvolume.roi[0]-border), throttle=False)
+                                (size_z, size_y, size_x),
+                                (subvolume.roi.z1-border, subvolume.roi.y1-border, subvolume.roi.x1-border), throttle=False)
                     else:   
                         return node_service.get_labels3D(str(pdconf["segmentation-name"]),
-                                (size3,size2,size1),
-                                (subvolume.roi[2]-border, subvolume.roi[1]-border, subvolume.roi[0]-border))
+                                (size_z, size_y, size_x),
+                                (subvolume.roi.z1-border, subvolume.roi.y1-border, subvolume.roi.x1-border))
                 preserve_seg = get_segmask()
 
                 orig_bodies = set(np.unique(preserve_seg))
@@ -693,16 +693,16 @@ class Segmentor(object):
 
             # determine which interface there is touching between subvolumes 
             if subvolume1.touches(subvolume1.roi.x1, subvolume1.roi.x2,
-                                subvolume2.roi.x1, subvolume2.roi.x2):
+                                  subvolume2.roi.x1, subvolume2.roi.x2):
                 x1 = x2/2 
                 x2 = x1 + 1
             if subvolume1.touches(subvolume1.roi.y1, subvolume1.roi.y2,
-                                subvolume2.roi.y1, subvolume2.roi.y2):
+                                  subvolume2.roi.y1, subvolume2.roi.y2):
                 y1 = y2/2 
                 y2 = y1 + 1
             
             if subvolume1.touches(subvolume1.roi.z1, subvolume1.roi.z2,
-                                subvolume2.roi.z1, subvolume2.roi.z2):
+                                  subvolume2.roi.z1, subvolume2.roi.z2):
                 z1 = z2/2 
                 z2 = z1 + 1
 

--- a/DVIDSparkServices/reconutils/Segmentor.py
+++ b/DVIDSparkServices/reconutils/Segmentor.py
@@ -582,13 +582,13 @@ class Segmentor(object):
             num_preserve = len(pdconf["bodies"])
         
         for subvolume, max_id in zip(subvolumes, max_ids):
-            offsets[subvolume.roi_id] = offset
+            offsets[subvolume.sv_index] = offset
             offset += max_id
             offset += num_preserve
         subvolume_offsets = self.context.sc.broadcast(offsets)
 
-        # (subvol, label_vol) => [ (roi_id_1, roi_id_2), (subvol, boundary_labels)), 
-        #                          (roi_id_1, roi_id_2), (subvol, boundary_labels)), ...] 
+        # (subvol, label_vol) => [ (sv_index_1, sv_index_2), (subvol, boundary_labels)), 
+        #                          (sv_index_1, sv_index_2), (subvol, boundary_labels)), ...] 
         def extract_boundaries(key_labels):
             # compute overlap -- assume first point is less than second
             def intersects(pt1, pt2, pt1_2, pt2_2):
@@ -611,7 +611,7 @@ class Segmentor(object):
             
             # iterate through all ROI partners
             for partner in subvolume.local_regions:
-                key1 = subvolume.roi_id
+                key1 = subvolume.sv_index
                 key2 = partner[0]
                 roi2 = partner[1]
                 if key2 < key1:
@@ -680,7 +680,7 @@ class Segmentor(object):
             subvolume1, boundary1 = boundary_list_list[0] 
             subvolume2, boundary2 = boundary_list_list[1] 
 
-            if subvolume1.roi_id > subvolume2.roi_id:
+            if subvolume1.sv_index > subvolume2.sv_index:
                 subvolume1, subvolume2 = subvolume2, subvolume1
                 boundary1, boundary2 = boundary2, boundary1
 
@@ -833,14 +833,14 @@ class Segmentor(object):
 
             
             # handle offsets in mergelist
-            offset1 = subvolume_offsets.value[subvolume1.roi_id] 
-            offset2 = subvolume_offsets.value[subvolume2.roi_id] 
+            offset1 = subvolume_offsets.value[subvolume1.sv_index] 
+            offset2 = subvolume_offsets.value[subvolume2.sv_index] 
             for merger in merge_list:
                 merger[0] = merger[0]+offset1
                 merger[1] = merger[1]+offset2
 
             # return id and mappings, only relevant for stack one
-            return (subvolume1.roi_id, merge_list)
+            return (subvolume1.sv_index, merge_list)
 
         # key, mapping1; key mapping2 => key, mapping1+mapping2
         def reduce_mappings(b1, b2):
@@ -913,7 +913,7 @@ class Segmentor(object):
             (subvolume, labels) = key_label_mapping
 
             # grab broadcast offset
-            offset = subvolume_offsets.value[subvolume.roi_id]
+            offset = subvolume_offsets.value[subvolume.sv_index]
 
             # check for body mask labels and protect from renumber
             mask_bodies =  None

--- a/DVIDSparkServices/reconutils/morpho.py
+++ b/DVIDSparkServices/reconutils/morpho.py
@@ -267,28 +267,28 @@ def stitch(sc, label_chunks):
         for partner in subvolume.local_regions:
             key1 = subvolume.sv_index
             key2 = partner[0]
-            roi2 = partner[1]
+            box2 = partner[1]
             if key2 < key1:
                 key1, key2 = key2, key1
             
             # crop volume to overlap
             offx1, offx2, offx1_2, offx2_2 = intersects(
-                            subvolume.roi.x1-subvolume.border,
-                            subvolume.roi.x2+subvolume.border,
-                            roi2.x1-subvolume.border,
-                            roi2.x2+subvolume.border
+                            subvolume.box.x1-subvolume.border,
+                            subvolume.box.x2+subvolume.border,
+                            box2.x1-subvolume.border,
+                            box2.x2+subvolume.border
                         )
             offy1, offy2, offy1_2, offy2_2 = intersects(
-                            subvolume.roi.y1-subvolume.border,
-                            subvolume.roi.y2+subvolume.border,
-                            roi2.y1-subvolume.border,
-                            roi2.y2+subvolume.border
+                            subvolume.box.y1-subvolume.border,
+                            subvolume.box.y2+subvolume.border,
+                            box2.y1-subvolume.border,
+                            box2.y2+subvolume.border
                         )
             offz1, offz2, offz1_2, offz2_2 = intersects(
-                            subvolume.roi.z1-subvolume.border,
-                            subvolume.roi.z2+subvolume.border,
-                            roi2.z1-subvolume.border,
-                            roi2.z2+subvolume.border
+                            subvolume.box.z1-subvolume.border,
+                            subvolume.box.z2+subvolume.border,
+                            box2.z1-subvolume.border,
+                            box2.z2+subvolume.border
                         )
                         
             labels_cropped = numpy.copy(labels[offz1:offz2, offy1:offy2, offx1:offx2])
@@ -344,17 +344,17 @@ def stitch(sc, label_chunks):
         z1 = y1 = x1 = 0 
 
         # determine which interface there is touching between subvolumes 
-        if subvolume1.touches(subvolume1.roi.x1, subvolume1.roi.x2,
-                              subvolume2.roi.x1, subvolume2.roi.x2):
+        if subvolume1.touches(subvolume1.box.x1, subvolume1.box.x2,
+                              subvolume2.box.x1, subvolume2.box.x2):
             x1 = x2/2 
             x2 = x1 + 1
-        if subvolume1.touches(subvolume1.roi.y1, subvolume1.roi.y2,
-                              subvolume2.roi.y1, subvolume2.roi.y2):
+        if subvolume1.touches(subvolume1.box.y1, subvolume1.box.y2,
+                              subvolume2.box.y1, subvolume2.box.y2):
             y1 = y2/2 
             y2 = y1 + 1
         
-        if subvolume1.touches(subvolume1.roi.z1, subvolume1.roi.z2,
-                              subvolume2.roi.z1, subvolume2.roi.z2):
+        if subvolume1.touches(subvolume1.box.z1, subvolume1.box.z2,
+                              subvolume2.box.z1, subvolume2.box.z2):
             z1 = z2/2 
             z2 = z1 + 1
 

--- a/DVIDSparkServices/reconutils/morpho.py
+++ b/DVIDSparkServices/reconutils/morpho.py
@@ -345,16 +345,16 @@ def stitch(sc, label_chunks):
 
         # determine which interface there is touching between subvolumes 
         if subvolume1.touches(subvolume1.roi.x1, subvolume1.roi.x2,
-                            subvolume2.roi.x1, subvolume2.roi.x2):
+                              subvolume2.roi.x1, subvolume2.roi.x2):
             x1 = x2/2 
             x2 = x1 + 1
         if subvolume1.touches(subvolume1.roi.y1, subvolume1.roi.y2,
-                            subvolume2.roi.y1, subvolume2.roi.y2):
+                              subvolume2.roi.y1, subvolume2.roi.y2):
             y1 = y2/2 
             y2 = y1 + 1
         
         if subvolume1.touches(subvolume1.roi.z1, subvolume1.roi.z2,
-                            subvolume2.roi.z1, subvolume2.roi.z2):
+                              subvolume2.roi.z1, subvolume2.roi.z2):
             z1 = z2/2 
             z2 = z1 + 1
 

--- a/DVIDSparkServices/sparkdvid/Subvolume.py
+++ b/DVIDSparkServices/sparkdvid/Subvolume.py
@@ -21,17 +21,17 @@ class Subvolume(object):
     
     """
 
-    def __init__(self, roi_id, roi, chunk_size, border):
+    def __init__(self, sv_index, roi, chunk_size, border):
         """Initializes subvolume.
 
         Args:
-            roi_id (int): identifier key for subvolume (must be unique)
+            sv_index (int): identifier key for subvolume (must be unique)
             roi ([]): x,y,z array
             chunk_size (int): dimension of subvolume (assume isotropic)
             border (int): border size surrounding core subvolume    
         """
 
-        self.roi_id = roi_id
+        self.sv_index = sv_index
         self.roi = SubvolumeNamedTuple(roi[0],
                     roi[1], roi[2],
                     roi[0] + chunk_size,
@@ -50,7 +50,7 @@ class Subvolume(object):
         self.intersecting_blocks = []
 
     def __eq__(self, other):
-        return (self.roi_id == other.roi_id and
+        return (self.sv_index == other.sv_index and
                 self.roi == other.roi and
                 self.border == other.border)
 
@@ -58,12 +58,12 @@ class Subvolume(object):
         return not self.__eq__(other)
     
     def __hash__(self):
-        # TODO: We still assume unique roi_ids, and only use that in the hash,
-        #       so that partitioning with roi_id is equivalent to partitioning on the Subvolume itself.
-        #       If sparkdvid functions (e.g. map_grayscale8) are ever changed not to partition over roi_id,
+        # TODO: We still assume unique sv_indexs, and only use that in the hash,
+        #       so that partitioning with sv_index is equivalent to partitioning on the Subvolume itself.
+        #       If sparkdvid functions (e.g. map_grayscale8) are ever changed not to partition over sv_index,
         #       then we can change this hash function to include the other members, such as border, etc.
-        #return hash( (self.roi_id, self.roi, self.border) )
-        return hash(self.roi_id)
+        #return hash( (self.sv_index, self.roi, self.border) )
+        return hash(self.sv_index)
 
     @property
     def roi_with_border(self):
@@ -109,8 +109,8 @@ class Subvolume(object):
         or (self.touches(liney1[0], liney1[1], liney2[0], liney2[1]) and self.intersects(linex1, linex2) and self.intersects(linez1, linez2)) \
         or (self.touches(linez1[0], linez1[1], linez2[0], linez2[1]) and self.intersects(liney1, liney2) and self.intersects(linex1, linex2)):
             # save overlapping substacks
-            self.local_regions.append((roi2.roi_id, roi2.roi))
-            roi2.local_regions.append((self.roi_id, self.roi))
+            self.local_regions.append((roi2.sv_index, roi2.roi))
+            roi2.local_regions.append((self.sv_index, self.roi))
 
 
 

--- a/DVIDSparkServices/sparkdvid/Subvolume.py
+++ b/DVIDSparkServices/sparkdvid/Subvolume.py
@@ -23,25 +23,25 @@ class Subvolume(object):
     
     """
 
-    def __init__(self, sv_index, roi_start_zyx, chunk_size, border):
+    def __init__(self, sv_index, box_start_zyx, chunk_size, border):
         """Initializes subvolume.
 
         Args:
             sv_index (int): identifier key for subvolume (must be unique)
-            roi_start_zyx: (z,y,x)
+            box_start_zyx: (z,y,x)
             chunk_size (int): dimension of subvolume (assume isotropic)
             border (int): border size surrounding core subvolume    
         """
 
         self.sv_index = sv_index
         
-        roi_stop_zyx = np.array(roi_start_zyx) + chunk_size
-        roi = np.array( (roi_start_zyx, roi_stop_zyx) )
-        self.roi = SubvolumeNamedTuple(*roi.flat)
+        box_stop_zyx = np.array(box_start_zyx) + chunk_size
+        box = np.array( (box_start_zyx, box_stop_zyx) )
+        self.box = SubvolumeNamedTuple(*box.flat)
         self.border = border
         self.local_regions = []
 
-        # ROI is always in 32x32x32 blocks for now
+        # ROI stored in DVID is always in 32x32x32 blocks for now
         self.roi_blocksize = 32
 
         # index off of (z,y,x) block indices
@@ -52,7 +52,7 @@ class Subvolume(object):
 
     def __eq__(self, other):
         return (self.sv_index == other.sv_index and
-                self.roi == other.roi and
+                self.box == other.box and
                 self.border == other.border)
 
     def __ne__(self, other):
@@ -63,23 +63,23 @@ class Subvolume(object):
         #       so that partitioning with sv_index is equivalent to partitioning on the Subvolume itself.
         #       If sparkdvid functions (e.g. map_grayscale8) are ever changed not to partition over sv_index,
         #       then we can change this hash function to include the other members, such as border, etc.
-        #return hash( (self.sv_index, self.roi, self.border) )
+        #return hash( (self.sv_index, self.box, self.border) )
         return hash(self.sv_index)
 
     @property
-    def roi_with_border(self):
+    def box_with_border(self):
         """
         Read-only property.
-        Same as self.roi, but expanded to include the border.
+        Same as self.box, but expanded to include the border.
         """
-        z1, y1, x1, z2, y2, x2 = self.roi
+        z1, y1, x1, z2, y2, x2 = self.box
         return SubvolumeNamedTuple(z1 - self.border, y1 - self.border, x1 - self.border,
                                    z2 + self.border, y2 + self.border, x2 + self.border)
 
 
     def __str__(self):
         return "z{z1}-y{y1}-x{x1}--z{z2}-y{y2}-x{x2}"\
-               .format(**self.roi.__dict__)
+               .format(**self.box.__dict__)
 
     # assume line[0] < line[1] and add border in calculation 
     def intersects(self, line1, line2):
@@ -96,22 +96,22 @@ class Subvolume(object):
             return True
         return False
 
-    # returns true if two rois overlap
-    def recordborder(self, roi2):
-        linex1 = [self.roi.x1, self.roi.x2]
-        linex2 = [roi2.roi.x1, roi2.roi.x2]
-        liney1 = [self.roi.y1, self.roi.y2]
-        liney2 = [roi2.roi.y1, roi2.roi.y2]
-        linez1 = [self.roi.z1, self.roi.z2]
-        linez2 = [roi2.roi.z1, roi2.roi.z2]
+    # returns true if two boxes overlap
+    def recordborder(self, box2):
+        linex1 = [self.box.x1, self.box.x2]
+        linex2 = [box2.box.x1, box2.box.x2]
+        liney1 = [self.box.y1, self.box.y2]
+        liney2 = [box2.box.y1, box2.box.y2]
+        linez1 = [self.box.z1, self.box.z2]
+        linez2 = [box2.box.z1, box2.box.z2]
        
         # check intersection
         if (self.touches(linex1[0], linex1[1], linex2[0], linex2[1]) and self.intersects(liney1, liney2) and self.intersects(linez1, linez2)) \
         or (self.touches(liney1[0], liney1[1], liney2[0], liney2[1]) and self.intersects(linex1, linex2) and self.intersects(linez1, linez2)) \
         or (self.touches(linez1[0], linez1[1], linez2[0], linez2[1]) and self.intersects(liney1, liney2) and self.intersects(linex1, linex2)):
             # save overlapping substacks
-            self.local_regions.append((roi2.sv_index, roi2.roi))
-            roi2.local_regions.append((self.sv_index, self.roi))
+            self.local_regions.append((box2.sv_index, box2.box))
+            box2.local_regions.append((self.sv_index, self.box))
 
 
 

--- a/DVIDSparkServices/sparkdvid/sparkdvid.py
+++ b/DVIDSparkServices/sparkdvid/sparkdvid.py
@@ -152,8 +152,8 @@ class sparkdvid(object):
         # Initialize each subvolume's 'intersecting_blocks' member for the ROI blocks it contains.
         for (_sid, subvol) in subvolumes:
             # Subvol bounding-box in pixels
-            subvol_start_px = np.array((subvol.roi.z1, subvol.roi.y1, subvol.roi.x1)) - subvol.border
-            subvol_stop_px  = np.array((subvol.roi.z2, subvol.roi.y2, subvol.roi.x2)) + subvol.border
+            subvol_start_px = np.array((subvol.box.z1, subvol.box.y1, subvol.box.x1)) - subvol.border
+            subvol_stop_px  = np.array((subvol.box.z2, subvol.box.y2, subvol.box.x2)) + subvol.border
             
             # Subvol bounding box in block coords
             subvol_blocks_start = subvol_start_px // subvol.roi_blocksize
@@ -233,9 +233,9 @@ class sparkdvid(object):
         def mapper(subvolume):
             # extract grayscale x
             # get sizes of subvolume
-            size_x = subvolume.roi.x2 + 2*subvolume.border - subvolume.roi.x1
-            size_y = subvolume.roi.y2 + 2*subvolume.border - subvolume.roi.y1
-            size_z = subvolume.roi.z2 + 2*subvolume.border - subvolume.roi.z1
+            size_x = subvolume.box.x2 + 2*subvolume.border - subvolume.box.x1
+            size_y = subvolume.box.y2 + 2*subvolume.border - subvolume.box.y1
+            size_z = subvolume.box.z2 + 2*subvolume.border - subvolume.box.z1
 
             #logger = logging.getLogger(__name__)
             #logger.warn("FIXME: As a temporary hack, this introduces a pause before accessing grayscale, to offset accesses to dvid")
@@ -243,7 +243,7 @@ class sparkdvid(object):
             #import random
             #time.sleep( random.randint(0,512) )
 
-            # retrieve data from roi start position considering border
+            # retrieve data from box start position considering border
             @auto_retry(3, pause_between_tries=60.0, logging_name=__name__)
             def get_gray():
                 # Note: libdvid uses zyx order for python functions
@@ -251,11 +251,11 @@ class sparkdvid(object):
                 if resource_server != "":
                     return node_service.get_gray3D( str(gray_name),
                                                     (size_z, size_y, size_x),
-                                                    (subvolume.roi.z1-subvolume.border, subvolume.roi.y1-subvolume.border, subvolume.roi.x1-subvolume.border), throttle=False )
+                                                    (subvolume.box.z1-subvolume.border, subvolume.box.y1-subvolume.border, subvolume.box.x1-subvolume.border), throttle=False )
                 else:
                     return node_service.get_gray3D( str(gray_name),
                                                     (size_z, size_y, size_x),
-                                                    (subvolume.roi.z1-subvolume.border, subvolume.roi.y1-subvolume.border, subvolume.roi.x1-subvolume.border) )
+                                                    (subvolume.box.z1-subvolume.border, subvolume.box.y1-subvolume.border, subvolume.box.x1-subvolume.border) )
 
             gray_volume = get_gray()
 
@@ -288,26 +288,26 @@ class sparkdvid(object):
         resource_port = self.workflow.resource_port
 
         def mapper(subvolume):
-            # get sizes of roi
-            size_x = subvolume.roi.x2 + 2*subvolume.border - subvolume.roi.x1
-            size_y = subvolume.roi.y2 + 2*subvolume.border - subvolume.roi.y1
-            size_z = subvolume.roi.z2 + 2*subvolume.border - subvolume.roi.z1
+            # get sizes of box
+            size_x = subvolume.box.x2 + 2*subvolume.border - subvolume.box.x1
+            size_y = subvolume.box.y2 + 2*subvolume.border - subvolume.box.y1
+            size_z = subvolume.box.z2 + 2*subvolume.border - subvolume.box.z1
 
             @auto_retry(3, pause_between_tries=60.0, logging_name=__name__)
             def get_labels():
                 # extract labels 64
-                # retrieve data from roi start position considering border
+                # retrieve data from box start position considering border
                 # Note: libdvid uses zyx order for python functions
                 node_service = retrieve_node_service(server, uuid, resource_server, resource_port)
                 if resource_server != "":
                     data = node_service.get_labels3D( str(label_name),
                                                       (size_z, size_y, size_x),
-                                                      (subvolume.roi.z1-subvolume.border, subvolume.roi.y1-subvolume.border, subvolume.roi.x1-subvolume.border),
+                                                      (subvolume.box.z1-subvolume.border, subvolume.box.y1-subvolume.border, subvolume.box.x1-subvolume.border),
                                                       compress=True, throttle=False )
                 else:
                     data = node_service.get_labels3D( str(label_name),
                                                       (size_z, size_y, size_x),
-                                                      (subvolume.roi.z1-subvolume.border, subvolume.roi.y1-subvolume.border, subvolume.roi.x1-subvolume.border),
+                                                      (subvolume.box.z1-subvolume.border, subvolume.box.y1-subvolume.border, subvolume.box.x1-subvolume.border),
                                                       compress=True )
 
                 # mask ROI
@@ -348,25 +348,25 @@ class sparkdvid(object):
         resource_port = self.workflow.resource_port
 
         def mapper(subvolume):
-            # get sizes of roi
-            size_x = subvolume.roi.x2 - subvolume.roi.x1
-            size_y = subvolume.roi.y2 - subvolume.roi.y1
-            size_z = subvolume.roi.z2 - subvolume.roi.z1
+            # get sizes of box
+            size_x = subvolume.box.x2 - subvolume.box.x1
+            size_y = subvolume.box.y2 - subvolume.box.y1
+            size_z = subvolume.box.z2 - subvolume.box.z1
 
             @auto_retry(3, pause_between_tries=60.0, logging_name=__name__)
             def get_labels():
                 # extract labels 64
-                # retrieve data from roi start position
+                # retrieve data from box start position
                 # Note: libdvid uses zyx order for python functions
                 node_service = retrieve_node_service(server, uuid, resource_server, resource_port)
                 if resource_server != "":
                     data = node_service.get_labels3D( str(label_name),
                                                       (size_z, size_y, size_x),
-                                                      (subvolume.roi.z1, subvolume.roi.y1, subvolume.roi.x1), throttle=False)
+                                                      (subvolume.box.z1, subvolume.box.y1, subvolume.box.x1), throttle=False)
                 else:
                     data = node_service.get_labels3D( str(label_name),
                                                       (size_z, size_y, size_x),
-                                                      (subvolume.roi.z1, subvolume.roi.y1, subvolume.roi.x1))
+                                                      (subvolume.box.z1, subvolume.box.y1, subvolume.box.x1))
 
 
                 # mask ROI
@@ -379,17 +379,17 @@ class sparkdvid(object):
             @auto_retry(3, pause_between_tries=60.0, logging_name=__name__)
             def get_labels2():
                 # fetch second label volume
-                # retrieve data from roi start position
+                # retrieve data from box start position
                 # Note: libdvid uses zyx order for python functions
                 node_service2 = retrieve_node_service(server2, uuid2, resource_server, resource_port)
                 if resource_server != "":
                     return node_service2.get_labels3D( str(label_name2),
                                                        (size_z, size_y, size_x),
-                                                       (subvolume.roi.z1, subvolume.roi.y1, subvolume.roi.x1), throttle=False)
+                                                       (subvolume.box.z1, subvolume.box.y1, subvolume.box.x1), throttle=False)
                 else:
                     return node_service2.get_labels3D( str(label_name2),
                                                        (size_z, size_y, size_x),
-                                                       (subvolume.roi.z1, subvolume.roi.y1, subvolume.roi.x1))
+                                                       (subvolume.box.z1, subvolume.box.y1, subvolume.box.x1))
 
             label_volume2 = get_labels2()
 
@@ -495,9 +495,9 @@ class sparkdvid(object):
             
             (key, (subvolume, seg)) = subvolume_seg
             # get sizes of subvolume 
-            size1 = subvolume.roi.x2-subvolume.roi.x1
-            size2 = subvolume.roi.y2-subvolume.roi.y1
-            size3 = subvolume.roi.z2-subvolume.roi.z1
+            size1 = subvolume.box.x2-subvolume.box.x1
+            size2 = subvolume.box.y2-subvolume.box.y1
+            size3 = subvolume.box.z2-subvolume.box.z1
 
             border = subvolume.border
 
@@ -509,19 +509,19 @@ class sparkdvid(object):
 
             @auto_retry(3, pause_between_tries=600.0, logging_name= __name__)
             def put_labels():
-                # send data from roi start position
+                # send data from box start position
                 # Note: libdvid uses zyx order for python functions
                 node_service = retrieve_node_service(server, uuid, resource_server, resource_port)
                 if roi_name is None:
                     node_service.put_labels3D( str(label_name),
                                                seg,
-                                               (subvolume.roi.z1, subvolume.roi.y1, subvolume.roi.x1),
+                                               (subvolume.box.z1, subvolume.box.y1, subvolume.box.x1),
                                                compress=True,
                                                mutate=mutate )
                 else: 
                     node_service.put_labels3D( str(label_name),
                                                seg,
-                                               (subvolume.roi.z1, subvolume.roi.y1, subvolume.roi.x1),
+                                               (subvolume.box.z1, subvolume.box.y1, subvolume.box.x1),
                                                compress=True,
                                                roi=str(roi_name),
                                                mutate=mutate )

--- a/DVIDSparkServices/util.py
+++ b/DVIDSparkServices/util.py
@@ -13,6 +13,24 @@ def bb_to_slicing(start, stop):
     """
     return tuple( starmap( slice, zip(start, stop) ) )
 
+class RoiMap(object):
+    """
+    Little utility class to help with ROI manipulations
+    """
+    def __init__(self, roi_blocks):
+        # Make a map of the entire ROI
+        # Since roi blocks are 32^2, this won't be too huge.
+        # For example, a ROI that's 10k*10k*100k pixels, this will be ~300 MB
+        # For a 100k^3 ROI, this will be 30 GB (still small enough to fit in RAM on the driver)
+        block_mask, (blocks_start, blocks_stop) = coordlist_to_boolmap(roi_blocks)
+        blocks_shape = blocks_stop - blocks_start
+
+        self.block_mask = block_mask
+        self.blocks_start = blocks_start
+        self.blocks_stop = blocks_stop
+        self.blocks_shape = blocks_shape
+        
+
 def coordlist_to_boolmap(coordlist, bounding_box=None):
     """
     Convert the given list of coordinates (z,y,x) into a 3D bool array.

--- a/DVIDSparkServices/util.py
+++ b/DVIDSparkServices/util.py
@@ -82,8 +82,8 @@ def dense_roi_mask_for_subvolume(subvolume, border='default'):
             "region, so I can't produce a mask outside that area."
     
     # subvol bounding box/shape (not block-aligned)
-    sv_start_px = np.array((sv.roi.z1, sv.roi.y1, sv.roi.x1)) - border
-    sv_stop_px  = np.array((sv.roi.z2, sv.roi.y2, sv.roi.x2)) + border
+    sv_start_px = np.array((sv.box.z1, sv.box.y1, sv.box.x1)) - border
+    sv_stop_px  = np.array((sv.box.z2, sv.box.y2, sv.box.x2)) + border
     sv_shape_px = sv_stop_px - sv_start_px
     
     # subvol bounding box/shape in block coordinates

--- a/DVIDSparkServices/util.py
+++ b/DVIDSparkServices/util.py
@@ -83,7 +83,7 @@ def dense_roi_mask_for_subvolume(subvolume, border='default'):
     
     # subvol bounding box/shape (not block-aligned)
     sv_start_px = np.array((sv.roi.z1, sv.roi.y1, sv.roi.x1)) - border
-    sv_stop_px = np.array((sv.roi.z2, sv.roi.y2, sv.roi.x2)) + border
+    sv_stop_px  = np.array((sv.roi.z2, sv.roi.y2, sv.roi.x2)) + border
     sv_shape_px = sv_stop_px - sv_start_px
     
     # subvol bounding box/shape in block coordinates

--- a/integration_tests/test_seg/config.json
+++ b/integration_tests/test_seg/config.json
@@ -4,6 +4,8 @@
         "uuid": "UUID1",
         "segmentation-name": "seglabels",
         "roi": "temproi256",
+        "partition-method": "grid-aligned",
+        "partition-filter": "all",
         "grayscale": "grayscale"
     },
     "options": {

--- a/workflows/ComputeEdgeProbs.py
+++ b/workflows/ComputeEdgeProbs.py
@@ -186,8 +186,7 @@ class ComputeEdgeProbs(DVIDWorkflow):
             # it might make sense to randomly map partitions for selection
             # in case something pathological is happening -- if original partitioner
             # is randomish than this should be fine
-            def subset_part(roi):
-                s_id, data = roi
+            def subset_part( (s_id, data) ):
                 if (s_id % num_iters) == iternum:
                     return True
                 return False
@@ -226,28 +225,28 @@ class ComputeEdgeProbs(DVIDWorkflow):
                 # extract labelblks
                 border = 1 # only one pixel needed to find edges
                 
-                # get sizes of roi
-                size_z = subvolume.roi.z2 + 2*border - subvolume.roi.z1
-                size_y = subvolume.roi.y2 + 2*border - subvolume.roi.y1
-                size_x = subvolume.roi.x2 + 2*border - subvolume.roi.x1
+                # get sizes of box
+                size_z = subvolume.box.z2 + 2*border - subvolume.box.z1
+                size_y = subvolume.box.y2 + 2*border - subvolume.box.y1
+                size_x = subvolume.box.x2 + 2*border - subvolume.box.x1
 
-                # retrieve data from roi start position considering border
+                # retrieve data from box start position considering border
                 # !! technically ROI is not respected but unwritten segmentation will be ignored since it will have 0-valued pixels.
                 @auto_retry(3, pause_between_tries=60.0, logging_name=__name__)
                 def get_seg():
                     node_service = retrieve_node_service(pdconf["dvid-server"], 
                             pdconf["uuid"], resource_server, resource_port)
-                    # retrieve data from roi start position
+                    # retrieve data from box start position
                     # Note: libdvid uses zyx order for python functions
                     
                     if resource_server != "": 
                         return node_service.get_labels3D(str(pdconf["segmentation-name"]),
                             (size_z, size_y, size_x),
-                            (subvolume.roi.z2-border, subvolume.roi.y1-border, subvolume.roi.x1-border))
+                            (subvolume.box.z2-border, subvolume.box.y1-border, subvolume.box.x1-border))
                     else:
                         return node_service.get_labels3D(str(pdconf["segmentation-name"]),
                              (size_z, size_y, size_x),
-                             (subvolume.roi.z2-border, subvolume.roi.y1-border, subvolume.roi.x1-border))
+                             (subvolume.box.z2-border, subvolume.box.y1-border, subvolume.box.x1-border))
 
                 initial_seg = get_seg()
 
@@ -270,13 +269,13 @@ class ComputeEdgeProbs(DVIDWorkflow):
                     for edge in features["Edges"]:
                         n1 = edge["Id1"]
                         n2 = edge["Id2"]
-                        edge["Loc1"][0] += subvolume.roi.x1
-                        edge["Loc1"][1] += subvolume.roi.y1
-                        edge["Loc1"][2] += subvolume.roi.z1
+                        edge["Loc1"][0] += subvolume.box.x1
+                        edge["Loc1"][1] += subvolume.box.y1
+                        edge["Loc1"][2] += subvolume.box.z1
                         
-                        edge["Loc2"][0] += subvolume.roi.x1
-                        edge["Loc2"][1] += subvolume.roi.y1
-                        edge["Loc2"][2] += subvolume.roi.z1
+                        edge["Loc2"][0] += subvolume.box.x1
+                        edge["Loc2"][1] += subvolume.box.y1
+                        edge["Loc2"][2] += subvolume.box.z1
                         
                         if n1 > n2:
                             n1, n2 = n2, n1

--- a/workflows/ComputeEdgeProbs.py
+++ b/workflows/ComputeEdgeProbs.py
@@ -227,9 +227,9 @@ class ComputeEdgeProbs(DVIDWorkflow):
                 border = 1 # only one pixel needed to find edges
                 
                 # get sizes of roi
-                size1 = subvolume.roi[3]+2*border-subvolume.roi[0]
-                size2 = subvolume.roi[4]+2*border-subvolume.roi[1]
-                size3 = subvolume.roi[5]+2*border-subvolume.roi[2]
+                size_z = subvolume.roi.z2 + 2*border - subvolume.roi.z1
+                size_y = subvolume.roi.y2 + 2*border - subvolume.roi.y1
+                size_x = subvolume.roi.x2 + 2*border - subvolume.roi.x1
 
                 # retrieve data from roi start position considering border
                 # !! technically ROI is not respected but unwritten segmentation will be ignored since it will have 0-valued pixels.
@@ -242,12 +242,12 @@ class ComputeEdgeProbs(DVIDWorkflow):
                     
                     if resource_server != "": 
                         return node_service.get_labels3D(str(pdconf["segmentation-name"]),
-                            (size3,size2,size1),
-                            (subvolume.roi[2]-border, subvolume.roi[1]-border, subvolume.roi[0]-border))
+                            (size_z, size_y, size_x),
+                            (subvolume.roi.z2-border, subvolume.roi.y1-border, subvolume.roi.x1-border))
                     else:
                         return node_service.get_labels3D(str(pdconf["segmentation-name"]),
-                            (size3,size2,size1),
-                            (subvolume.roi[2]-border, subvolume.roi[1]-border, subvolume.roi[0]-border))
+                             (size_z, size_y, size_x),
+                             (subvolume.roi.z2-border, subvolume.roi.y1-border, subvolume.roi.x1-border))
 
                 initial_seg = get_seg()
 
@@ -270,13 +270,13 @@ class ComputeEdgeProbs(DVIDWorkflow):
                     for edge in features["Edges"]:
                         n1 = edge["Id1"]
                         n2 = edge["Id2"]
-                        edge["Loc1"][0] += subvolume.roi[0]
-                        edge["Loc1"][1] += subvolume.roi[1]
-                        edge["Loc1"][2] += subvolume.roi[2]
+                        edge["Loc1"][0] += subvolume.roi.x1
+                        edge["Loc1"][1] += subvolume.roi.y1
+                        edge["Loc1"][2] += subvolume.roi.z1
                         
-                        edge["Loc2"][0] += subvolume.roi[0]
-                        edge["Loc2"][1] += subvolume.roi[1]
-                        edge["Loc2"][2] += subvolume.roi[2]
+                        edge["Loc2"][0] += subvolume.roi.x1
+                        edge["Loc2"][1] += subvolume.roi.y1
+                        edge["Loc2"][2] += subvolume.roi.z1
                         
                         if n1 > n2:
                             n1, n2 = n2, n1

--- a/workflows/ConnectedComponents.py
+++ b/workflows/ConnectedComponents.py
@@ -146,7 +146,7 @@ class ConnectedComponents(DVIDWorkflow):
         # This is to make the foreach_write_labels3d() function happy
         def prepend_key(item):
             subvol, _ = item
-            return (subvol.roi_id, item)
+            return (subvol.sv_index, item)
         mapped_seg_chunks = mapped_seg_chunks.map(prepend_key)
        
         # use fewer partitions (TEMPORARY SINCE THERE ARE WRITE BANDWIDTH LIMITS TO DVID)

--- a/workflows/CreateSegmentation.py
+++ b/workflows/CreateSegmentation.py
@@ -247,8 +247,7 @@ class CreateSegmentation(DVIDWorkflow):
             # it might make sense to randomly map partitions for selection
             # in case something pathological is happening -- if original partitioner
             # is randomish than this should be fine
-            def subset_part(roi):
-                s_id, data = roi
+            def subset_part( (s_id, data) ):
                 if (s_id % num_iters) == iternum:
                     return True
                 return False
@@ -273,7 +272,7 @@ class CreateSegmentation(DVIDWorkflow):
             # Load as many seg blocks from cache as possible
             if subvols_with_seg_cache:
                 def retrieve_seg_from_cache(subvol):
-                    z1, y1, x1, z2, y2, x2 = subvol.roi_with_border
+                    z1, y1, x1, z2, y2, x2 = subvol.box_with_border
                     block_bounds = ((z1, y1, x1), (z2, y2, x2))
                     block_store = H5BlockStore(seg_checkpoint_dir, mode='r')
                     h5_block = block_store.get_block( block_bounds )
@@ -401,7 +400,7 @@ class CreateSegmentation(DVIDWorkflow):
             return [], subvol_list
 
         def is_cached(subvol):
-            z1, y1, x1, z2, y2, x2 = subvol.roi_with_border
+            z1, y1, x1, z2, y2, x2 = subvol.box_with_border
             if block_store.axes[-1] == 'c':
                 return ((z1, y1, x1, 0), (z2, y2, x2, None)) in block_store
             else:

--- a/workflows/CreateSegmentation.py
+++ b/workflows/CreateSegmentation.py
@@ -294,9 +294,9 @@ class CreateSegmentation(DVIDWorkflow):
             uncached_subvols = self.sparkdvid_context.sc.parallelize(subvols_without_seg_cache, len(subvols_without_seg_cache) or None)
             uncached_subvols.persist()
 
-            def prepend_roi_id(subvol):
-                return (subvol.roi_id, subvol)
-            uncached_subvols_kv_rdd = uncached_subvols.map(prepend_roi_id)
+            def prepend_sv_index(subvol):
+                return (subvol.sv_index, subvol)
+            uncached_subvols_kv_rdd = uncached_subvols.map(prepend_sv_index)
 
             # get grayscale chunks with specified overlap
             uncached_sv_and_gray = self.sparkdvid_context.map_grayscale8(uncached_subvols_kv_rdd,
@@ -348,7 +348,7 @@ class CreateSegmentation(DVIDWorkflow):
         
         def prepend_key(item):
             subvol, _ = item
-            return (subvol.roi_id, item)
+            return (subvol.sv_index, item)
         mapped_seg_chunks = mapped_seg_chunks.map(prepend_key)
        
         if self.config_data["options"]["parallelwrites"] > 0:

--- a/workflows/CreateSegmentation.py
+++ b/workflows/CreateSegmentation.py
@@ -45,6 +45,19 @@ class CreateSegmentation(DVIDWorkflow):
               "type": "string",
               "minLength": 1
             },
+            "partition-method": {
+              "description": "Strategy to dvide the ROI into substacks for processing.",
+              "type": "string",
+              "minLength": 1,
+              "default": "ask-dvid"
+            },
+            "partition-filter": {
+              "description": "Optionally remove substacks from the compute set based on some criteria",
+              "type": "string",
+              "minLength": 1,
+              "enum": ["all", "interior-only"],
+              "default": "all"
+            },
             "grayscale": {
               "description": "grayscale data to segment",
               "type": "string",
@@ -195,7 +208,10 @@ class CreateSegmentation(DVIDWorkflow):
         # grab ROI subvolumes and find neighbors
         distsubvolumes = self.sparkdvid_context.parallelize_roi(
                 self.config_data["dvid-info"]["roi"],
-                self.chunksize, self.overlap/2, True)
+                self.chunksize, self.overlap/2,
+                True,
+                self.config_data["dvid-info"]["partition-method"],
+                self.config_data["dvid-info"]["partition-filter"] )
 
         # do not recompute ROI for each iteration
         distsubvolumes.persist()

--- a/workflows/CreateSegmentation.py
+++ b/workflows/CreateSegmentation.py
@@ -273,7 +273,7 @@ class CreateSegmentation(DVIDWorkflow):
             # Load as many seg blocks from cache as possible
             if subvols_with_seg_cache:
                 def retrieve_seg_from_cache(subvol):
-                    x1, y1, z1, x2, y2, z2 = subvol.roi_with_border
+                    z1, y1, x1, z2, y2, x2 = subvol.roi_with_border
                     block_bounds = ((z1, y1, x1), (z2, y2, x2))
                     block_store = H5BlockStore(seg_checkpoint_dir, mode='r')
                     h5_block = block_store.get_block( block_bounds )
@@ -401,7 +401,7 @@ class CreateSegmentation(DVIDWorkflow):
             return [], subvol_list
 
         def is_cached(subvol):
-            x1, y1, z1, x2, y2, z2 = subvol.roi_with_border
+            z1, y1, x1, z2, y2, x2 = subvol.roi_with_border
             if block_store.axes[-1] == 'c':
                 return ((z1, y1, x1, 0), (z2, y2, x2, None)) in block_store
             else:


### PR DESCRIPTION
This PR implements two little features related to ROI partitioning (mostly useful for debugging).

But the more important things to note in this PR are the refactoring commits (related to the `Subvolume` class).  They're relatively minor, but they touched a lot of files.  If you have any unmerged branches lying around, you might have to update them before merging them.  Specifically, I'm talking about these changes:

- 3a790407ea828bfd0017834f99d875796bfaffda: Renamed `Subvolume.roi_id` -> `.sv_index`.  "Roi ID" sounds a little too much like "roi name" which is a different concept.

- 4757046: Rename `Subvolume.roi` -> `Subvolume.box` to avoid confusion between DVID rois and subvolume bounding boxes

- 6caf30c: `Subvolume.box` is now in z-y-x order, not xyz.  For unfortunate historical reasons, this repo used xyz conventions in some places and zyx conventions in other places.  Now we use zyx basically everywhere, except for a few JSON fields.  This touched a lot of files, but I'm pretty sure I caught all the lines that needed to change.